### PR TITLE
feat: add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /log
 /pkgroot
 /source
+
+# Nix
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ The binaries are built on the latest PHP version and are statically linked, mean
 extensions.
 To view the list of installed extensions, run `pasir -m` command.
 
+#### Using Nix
+
+```bash
+# Build with default PHP 8.4
+nix build
+
+# Build with a specific PHP version
+nix build .#php85
+```
+
+Available packages: `php82`, `php83`, `php84` (default), `php85`.
+
 #### Using Homebrew
 
 ```bash
@@ -252,6 +264,20 @@ We welcome contributions! Please see our development guidelines:
 4. **Security**: Review any unsafe blocks and PHP integration code carefully
 
 ### Development Setup
+
+#### Using Nix
+
+```bash
+git clone <repository-url>
+cd pasir
+nix develop
+cargo build
+```
+
+The dev shell provides Rust, PHP (ZTS + embed), clang, and all build dependencies.
+Other PHP versions are available: `nix develop .#php82`, `.#php83`, `.#php85`.
+
+#### Manual Setup
 
 ```bash
 # Clone and setup

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773507054,
+        "narHash": "sha256-Q8U5VXgrcxmCxPtCCJCIZkcAX3FCZwGh1GNVIXxMND0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e80236013dc8b77aa49ca90e7a12d86f5d8d64c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,113 @@
+{
+  description = "Pasir - PHP Application Server In Rust";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+
+        mkPhp = phpPkg:
+          let
+            phpWithFlags = phpPkg.override {
+              embedSupport = true;
+              ztsSupport = true;
+              zendSignalsSupport = false;
+              zendMaxExecutionTimersSupport = pkgs.stdenv.isLinux;
+            };
+          in phpWithFlags.unwrapped;
+
+        phpVersions = {
+          php82 = mkPhp pkgs.php82;
+          php83 = mkPhp pkgs.php83;
+          php84 = mkPhp pkgs.php84;
+          php85 = mkPhp pkgs.php85;
+        };
+
+        src = pkgs.lib.cleanSourceWith {
+          src = craneLib.path ./.;
+          filter = path: type:
+            (craneLib.filterCargoSources path type)
+            || (builtins.match ".*\\.h$" path != null)
+            || (builtins.match ".*craft\\.yml$" path != null)
+            || (builtins.match ".*/patches/.*" path != null)
+            || (builtins.match ".*/patches$" path != null)
+            || (builtins.match ".*llvm-config$" path != null)
+            || (builtins.match ".*/build/.*" path != null)
+            || (builtins.match ".*/build$" path != null);
+        };
+
+        mkPasir = php:
+          let
+            commonArgs = {
+              inherit src;
+              strictDeps = true;
+              pname = "pasir";
+              doCheck = false;
+
+              nativeBuildInputs = [
+                pkgs.llvmPackages.libclang
+                pkgs.clang
+                pkgs.pkg-config
+              ];
+
+              buildInputs = [ php php.dev ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                pkgs.libiconv
+                pkgs.darwin.apple_sdk.frameworks.Security
+              ];
+
+              LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+              BINDGEN_EXTRA_CLANG_ARGS = pkgs.lib.optionals pkgs.stdenv.isLinux
+                (builtins.map (a: ''-isystem ${a}/include'') [
+                  pkgs.stdenv.cc.cc
+                  pkgs.glibc.dev
+                ]);
+              PHP = "${php}/bin/php";
+              PHP_CONFIG = "${php.dev}/bin/php-config";
+            };
+
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          in
+          craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+          });
+
+        mkDevShell = php: craneLib.devShell {
+          inputsFrom = [ (mkPasir php) ];
+
+          packages = [
+            pkgs.rust-analyzer
+            pkgs.cargo-nextest
+            php
+          ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          PHP = "${php}/bin/php";
+        };
+
+      in
+      {
+        packages = {
+          default = mkPasir phpVersions.php84;
+          php82 = mkPasir phpVersions.php82;
+          php83 = mkPasir phpVersions.php83;
+          php84 = mkPasir phpVersions.php84;
+          php85 = mkPasir phpVersions.php85;
+        };
+
+        devShells = {
+          default = mkDevShell phpVersions.php84;
+          php82 = mkDevShell phpVersions.php82;
+          php83 = mkDevShell phpVersions.php83;
+          php84 = mkDevShell phpVersions.php84;
+          php85 = mkDevShell phpVersions.php85;
+        };
+      }
+    );
+}


### PR DESCRIPTION
We're adding Nix flake with runtime packages and dev shells for PHP 8.2–8.5 (default 8.4)

Note: static build is not available as SPC needs root privilege, and cross-MUSL compilation has limitations with PHP